### PR TITLE
Fix area calculation overflow

### DIFF
--- a/Core/chipsim.cpp
+++ b/Core/chipsim.cpp
@@ -158,8 +158,8 @@ bool getNodeValue() {
 		return true;
 	}
 
-	int hi_area = 0;
-	int lo_area = 0;
+	int64_t hi_area = 0;
+	int64_t lo_area = 0;
 	for(uint16_t nn : group) {
 		node &n = nodes[nn];
 		if(n.pullup) return true;

--- a/Core/datadefs.cpp
+++ b/Core/datadefs.cpp
@@ -2,7 +2,7 @@
 #include "datastructures.h"
 #include "datadefs.h"
 
-vector<vector<int>> segdefs;
+vector<vector<int64_t>> segdefs;
 vector<transdef> transdefs;
 unordered_map<string, uint16_t> nodenames;
 vector<vector<vector<int>>> palette_nodes;
@@ -68,7 +68,7 @@ void loadSegmentDefinitions()
 			}
 
 			vector<string> values = split(lineContent, ',');
-			vector<int> segDef;
+			vector<int64_t> segDef;
 			for(string value : values) {
 				if(segDef.empty()) {
 					segDef.push_back(convertId(std::stoi(value) + segmentIdOffset));

--- a/Core/datadefs.h
+++ b/Core/datadefs.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "datastructures.h"
 
-extern vector<vector<int>> segdefs;
+extern vector<vector<int64_t>> segdefs;
 extern vector<transdef> transdefs;
 extern unordered_map<string, uint16_t> nodenames;
 extern vector<vector<vector<int>>> palette_nodes;

--- a/Core/datastructures.h
+++ b/Core/datastructures.h
@@ -27,7 +27,7 @@ struct node
 	bool pulldown = false;
 	bool floating = true;
 	
-	int area = 0;
+	int64_t area = 0;
 	uint16_t num = EMPTYNODE;
 	vector<uint16_t> gates;
 	vector<vector<uint16_t>> segs;

--- a/Core/wires.cpp
+++ b/Core/wires.cpp
@@ -34,14 +34,14 @@ unordered_map<uint16_t, std::string> nodenameByNumber;
 
 void setupNodes() 
 {
-	int maxID = 0;
+	int64_t maxID = 0;
 	for(size_t i = 0, len = segdefs.size(); i < len; i++) {
 		maxID = std::max(maxID, segdefs[i][0]);
 	}
 	nodes.insert(nodes.end(), maxID + 1, node());
 
 	for(size_t i = 0, len = segdefs.size(); i < len; i++) {
-		std::vector<int> &seg = segdefs[i];
+		std::vector<int64_t> &seg = segdefs[i];
 		int w = seg[0];
 
 		if(nodes[w].num == EMPTYNODE) {


### PR DESCRIPTION
Caught this while porting to rust and using Visual NES as a reference. 

For certain nodes, calculating area overflows and becomes negative. This ultimately affects the state returned by `getNodeValue` and turn the wrong transistors on/off. I did a cursory test with the scanline test rom and it rendered the initial text as expected. I didn't leave it running particularly long.